### PR TITLE
Fix ANF export policy rules to handle existing vs new virtual networks

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_landscape/anf.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/anf.tf
@@ -166,7 +166,9 @@ resource "azurerm_netapp_volume" "transport" {
   export_policy_rule {
                        allowed_clients     = length(var.ANF_settings.export_policy_client_access_list) > 0 ? (
                                                     var.ANF_settings.export_policy_client_access_list ) : (
-                                                      azurerm_virtual_network.vnet_sap.address_space )
+                                                      var.infrastructure.virtual_networks.sap.exists ? (
+                                                        data.azurerm_virtual_network.vnet_sap[0].address_space) : (
+                                                        azurerm_virtual_network.vnet_sap[0].address_space) )
                        protocol            = ["NFSv4.1"]
                        rule_index          = 1
                        unix_read_only      = false
@@ -282,7 +284,9 @@ resource "azurerm_netapp_volume" "install" {
   export_policy_rule {
                        allowed_clients     = length(var.ANF_settings.export_policy_client_access_list) > 0 ? (
                                                     var.ANF_settings.export_policy_client_access_list ) : (
-                                                      azurerm_virtual_network.vnet_sap.address_space )
+                                                      var.infrastructure.virtual_networks.sap.exists ? (
+                                                        data.azurerm_virtual_network.vnet_sap[0].address_space) : (
+                                                        azurerm_virtual_network.vnet_sap[0].address_space) )
                        protocol            = ["NFSv4.1"]
                        rule_index          = 1
                        unix_read_only      = false


### PR DESCRIPTION
### Problem
The ANF export policy allowed_clients in [anf.tf](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) referenced azurerm_virtual_network.vnet_sap.address_space directly, which fails when using an existing virtual network (via data source) rather than creating a new one.

### Solution
Updated the export_policy_rule blocks for both the transport and install ANF volumes to conditionally resolve the address space:

If var.infrastructure.virtual_networks.sap.exists is true, use data.azurerm_virtual_network.vnet_sap[0].address_space. 
Otherwise, use azurerm_virtual_network.vnet_sap[0].address_space
