### PR TITLE
Fix SPN/MSI authentication for GitHub Actions deployments

### DIFF
--- a/deploy/scripts/pipeline_scripts/v2/shared_platform_config.sh
+++ b/deploy/scripts/pipeline_scripts/v2/shared_platform_config.sh
@@ -64,6 +64,12 @@ configure_platform_variables() {
 
 		# Setup output for GitHub Actions
 		export GITHUB_OUTPUT=${GITHUB_OUTPUT:-/dev/null}
+
+		if [ "${USE_MSI:-false}" != "true" ]; then
+			export TF_VAR_use_spn=true
+		else
+			export TF_VAR_use_spn=false
+		fi
 	elif [ "${PLATFORM}" == "devops" ]; then
 		# Map Azure DevOps variables to common names
 		[ ! -v SAP_AUTOMATION_REPO_PATH ] && export SAP_AUTOMATION_REPO_PATH="${SYSTEM_DEFAULTWORKINGDIRECTORY}/sap-automation"

--- a/deploy/terraform/run/sap_landscape/providers.tf
+++ b/deploy/terraform/run/sap_landscape/providers.tf
@@ -18,7 +18,7 @@
 provider "azurerm"                     {
                                          features {}
                                          subscription_id            = coalesce(var.management_subscription_id,var.subscription_id, local.deployer_subscription_id)
-                                         use_msi                    = true
+                                         use_msi                    = var.use_spn ? false : true
                                          storage_use_azuread        = true
                                        }
 
@@ -87,10 +87,9 @@ provider "azurerm"                     {
 provider "azurerm"                     {
                                          features {}
                                          subscription_id            = coalesce(var.management_dns_subscription_id, local.SAPLibrary_subscription_id, length(local.deployer_subscription_id) > 0 ? local.deployer_subscription_id : "")
-                                         use_msi                    = true
+                                         use_msi                    = var.use_spn ? false : true
                                          alias                      = "peering"
                                          storage_use_azuread        = true
-
                                        }
 
 provider "azuread"                     {


### PR DESCRIPTION
### Description:

This PR fixes two issues in the authentication chain when deploying SAP workload zones via GitHub Actions with Service Principal (SPN) authentication.

### Problem
When running deployments through GitHub Actions with USE_MSI=false (SPN auth), Terraform was still attempting MSI authentication, resulting in:

`ManagedIdentityAuthorizer: failed to request token from metadata endpoint: Identity not found`

### Root causes:

The default and peering AzureRM providers in `providers.tf` had `use_msi = true` hardcoded, ignoring the `var.use_spn` variable that all other providers correctly referenced.

The `TF_VAR_use_spn` environment variable was never set for the GitHub Actions platform. The LogonToAzure() function that sets this variable is only called inside the `PLATFORM == "devops"` (Azure DevOps) code path, leaving GitHub Actions deployments with the Terraform default of `use_spn = false`.

### Changes
`providers.tf` Changed the default and peering providers from `use_msi = true` to `use_msi = var.use_spn ? false : true`, consistent with all other providers.

`shared_platform_config.sh` Added `TF_VAR_use_spn` export in the GitHub platform block, deriving it from the pipeline's USE_MSI variable. This is the centralized equivalent of what LogonToAzure() does for Azure DevOps, and covers all 11 v2 scripts that depend on this variable.Description: