### PR TITLE
Fix Oracle Data Guard lock cleanup

### DIFF
--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-restart-instance.yaml
@@ -111,7 +111,7 @@
       become:                          true
       become_user:                     root
       ansible.builtin.file:
-        path:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/ls{{ current_sid }}"
+        path:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/lk{{ current_sid }}"
         state:                         absent
       failed_when:                     false
 

--- a/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
+++ b/deploy/ansible/roles-db/4.1.3-oracle-data-guard/tasks/00-validate-primary.yaml
@@ -121,7 +121,7 @@
       become:                          true
       become_user:                     root
       ansible.builtin.file:
-        path:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/ls{{ db_sid | upper }}"
+        path:                          "/oracle/{{ db_sid | upper }}/{{ ora_version }}/dbs/lk{{ db_sid | upper }}"
         state:                         absent
       failed_when:                     false
 


### PR DESCRIPTION
Correct the file paths in the Oracle Data Guard tasks to ensure proper lock cleanup during instance restart and validation.