### PR TITLE
Fix Windows AD group membership syntax

### DIFF
--- a/deploy/ansible/roles-sap-os/windows/2.3-sap-exports/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/windows/2.3-sap-exports/tasks/main.yaml
@@ -31,7 +31,7 @@
     description:                       Share Installation Files Accross Servers
     path:                              "{{ target_media_location_windows }}"
     list:                              true
-    full:                              '{{ orchestration_ansible_user }},SAP_{{ sap_sid | upper }}_LocalAdmin,SAP_{{ sap_sid | upper }}_GlobalAdmin@{{ domain_name }},{{ domain_service_account }}@{{ domain_name }},{{ sql_svc_account }}'
+    full:                              '{{ orchestration_ansible_user }},SAP_{{ sap_sid | upper }}_LocalAdmin,{{ domain }}\SAP_{{ sap_sid | upper }}_GlobalAdmin,{{ domain_service_account }}@{{ domain_name }},{{ sql_svc_account }}'
     state:                             present
   register:                            win_share_info
   when:

--- a/deploy/ansible/roles-sap-os/windows/2.5-sap-users/tasks/add_group_members.yaml
+++ b/deploy/ansible/roles-sap-os/windows/2.5-sap-users/tasks/add_group_members.yaml
@@ -9,7 +9,7 @@
   ansible.windows.win_group_membership:
     name:                                   "SAP_{{ sap_sid | upper }}_LocalAdmin"
     members:
-      - '{{ win_sap_admin }}@{{ domain_name }}'
+      - '{{ domain }}\{{ win_sap_admin }}'
       - '{{ sap_sid }}adm@{{ domain_name }}'
     state:                                  present
   notify:                                   reboot


### PR DESCRIPTION
Use DOMAIN\\Group for the SAP global admin group in Windows group membership and file share permissions so the module can resolve the AD group SID correctly.